### PR TITLE
Use desktop-qt5, desktop-launch and some stage-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,8 +13,7 @@ confinement: strict
 
 apps:
   paraview:
-    # command: desktop-launch bin/paraview
-    command: bin/paraview
+    command: desktop-launch $SNAP/bin/paraview
     plugs:
       - x11
       - opengl
@@ -73,5 +72,8 @@ parts:
   paraview:
     source: http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.3&type=binary&os=linux64&downloadFile=ParaView-5.3.0-Qt5-OpenGL2-MPI-Linux-64bit.tar.gz
     plugin: dump
+    stage-packages:
+      - libsm6
+      - libxt6
     after:
-      - desktop-ubuntu-app-platform
+      - desktop-qt5


### PR DESCRIPTION
Hey, here are a few tweaks to make the UI appear, unfortunately the UI stays black as it fails to OpenGL, so you might need to adjust some env variable paths when launching the app (see https://forum.snapcraft.io/t/declaratively-defining-environment-variables/175 for an example on how to do this).

Small tip: to figure out the correct stage-packages that are needed in a snap, it's often a matter of launching it, seeing on what it fails and looking which package provides the missing .so